### PR TITLE
Remove MAXLENGTH option from bloomrec RECORD

### DIFF
--- a/Bloom.ecl
+++ b/Bloom.ecl
@@ -58,7 +58,7 @@ EXPORT Bloom := MODULE,FORWARD
      * @return Bloom table
      */
     EXPORT bloomrec := RECORD
-      DATA bits { maxlength(tablesize) };
+      DATA bits;
     END;
 
     EXPORT TRANSFORM(bloomrec) addBloom(UNSIGNED4 hash1, UNSIGNED4 hash2, UNSIGNED4 _numhashes = numHashes, UNSIGNED _tablesize=tableSize) := BEGINC++


### PR DESCRIPTION
Not strictly needed, and removing it makes the code more flexible when callers are managing multiple Bloom filters.

Signed-off-by: Dan S. Camper <dan.camper@lexisnexisrisk.com>